### PR TITLE
Jellyfin - Unsetting PATH during `find ... -execdir`

### DIFF
--- a/src/jellyfin/devcontainer-feature.json
+++ b/src/jellyfin/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
     "name": "Jellyfin",
     "id": "jellyfin",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "Provides the Jellyfin media and Web UI servers.",
     "options": {
         "version": {

--- a/src/jellyfin/install.sh
+++ b/src/jellyfin/install.sh
@@ -25,7 +25,7 @@ install_binaries() {
     rm ${_release}
     ln -s jellyfin_${INSTALL_VERSION} jellyfin
     mkdir -p data cache config log
-    find ${JELLYFIN_HOME} -type d -execdir chmod 755 "{}" \;
+    PATH=/usr/bin find ${JELLYFIN_HOME} -type d -execdir chmod 755 "{}" \;
     chmod -R a+w $JELLYFIN_HOME
 }
 


### PR DESCRIPTION
## Summary

Attempt to solve the following problem when installing in https://github.com/jesseward/jellyfin-plugin-lastfm devcontainer


> #17 70.48 find: The relative path '~/.dotnet/tools' is included in the PATH environment variable, which is insecure in combination with the -execdir action of find.  Please remove that entry from $PATH
